### PR TITLE
fix mislabeled Al Oula and add AlOulaMiddleEast in elcinema

### DIFF
--- a/sites/elcinema.com/elcinema.com.channels.xml
+++ b/sites/elcinema.com/elcinema.com.channels.xml
@@ -3,7 +3,8 @@
   <channel site="elcinema.com" lang="ar" xmltv_id="2MInternational.ma" site_id="1353">2M Monde</channel>
   <channel site="elcinema.com" lang="ar" xmltv_id="AbuDhabiDrama.ae" site_id="1178">Abu Dhabi Drama</channel>
   <channel site="elcinema.com" lang="ar" xmltv_id="AbuDhabiTV.ae" site_id="1136">Abu Dhabi TV</channel>
-  <channel site="elcinema.com" lang="ar" xmltv_id="AlAoulaMiddleEast.ma" site_id="1101">Al Aoula Middle East</channel>
+  <channel site="elcinema.com" lang="ar" xmltv_id="ERTU1.eg" site_id="1101">Al Oula</channel>
+  <channel site="elcinema.com" lang="ar" xmltv_id="AlAoulaMiddleEast.ma" site_id="1312">Al Aoula Middle East</channel>
   <channel site="elcinema.com" lang="ar" xmltv_id="AlArabyTV2.uk" site_id="1382">Al Araby 2 TV</channel>
   <channel site="elcinema.com" lang="ar" xmltv_id="AlDafrahTV.ae" site_id="1264">Al Dafrah TV</channel>
   <channel site="elcinema.com" lang="ar" xmltv_id="AlhayatTV.eg" site_id="1137">Al Hayat</channel>


### PR DESCRIPTION
fixes mislabeled channel "AlOulaMiddleEast.ma" to "ERTU1.eg" and adds the correct entry for "AlOulaMiddleEast.ma"